### PR TITLE
Update install.pp

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -15,7 +15,7 @@
 define kmod::install(
   $ensure=present,
   $command='/bin/true',
-  $file="/etc/modprobe.conf/${name}.conf",
+  $file="/etc/modprobe.d/${name}.conf",
 ) {
 
   kmod::setting { "kmod::install ${title}":


### PR DESCRIPTION
Fix: changed $file parameter on install.pp file, since the directory where the ".conf" files are stored is defined as "modprobe.conf" instead of "modprobe.d". 