### PR TITLE
Also fail if ruby-augeas is not installed

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,10 @@
 #
 class kmod {
 
+  if $::augeasversion == undef {
+    fail('gem ruby-augeas required')  
+  }
+
   if versioncmp($::augeasversion, '0.9.0') < 0 {
     fail('Augeas 0.10.0 or higher required')
   }


### PR DESCRIPTION
On my OS X installation, I could not run some tests of the puppet-community/puppet-network module because puppet-kmod was telling me Augeas 0.10.0 or higher was required. I didn't have Augeas installed at all, but a brew call later, I had 1.3.0 on the disc. But still, Puppet didn't have `$::augeasversion` until I installed ruby-augeas.

I'm not sure ruby-augeas fits into the Gemfile as well. In my case I don't think puppet-kmod's Gemfile is even considered. But a more specific error message as to what is happening is better in any case.
