### PR TITLE
Minimal Suse Support, developed and tested on SLES11 SP3

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -27,6 +27,12 @@
       ]
     },
     {
+      "operatingsystem": "SLES",
+      "operatingsystemrelease": [
+        "11"
+      ]
+    },
+    {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "5",

--- a/spec/defines/kmod_load_spec.rb
+++ b/spec/defines/kmod_load_spec.rb
@@ -21,6 +21,12 @@ describe 'kmod::load', :type => :define do
             'lens'    => 'Modules.lns',
             'changes' => "clear 'foo'"
           }) }
+        when 'Suse'
+          it { should contain_augeas('sysconfig_kernel_MODULES_LOADED_ON_BOOT_foo').with({
+            'incl'    => '/foo/bar',
+            'lens'    => 'Shellvars_list.lns',
+            'changes' => "set MODULES_LOADED_ON_BOOT/value[.='foo'] 'foo'"
+          }) }
         when 'RedHat'
           it { should contain_file('/etc/sysconfig/modules/foo.modules').with({
             'ensure'  => 'present',
@@ -42,6 +48,12 @@ describe 'kmod::load', :type => :define do
             'lens'    => 'Modules.lns',
             'changes' => "rm 'foo'"
           })}
+        when 'Suse'
+          it { should contain_augeas('sysconfig_kernel_MODULES_LOADED_ON_BOOT_foo').with({
+            'incl'    => '/foo/bar',
+            'lens'    => 'Shellvars_list.lns',
+            'changes' => "rm MODULES_LOADED_ON_BOOT/value[.='foo']"
+          }) }
         when 'RedHat'
           it { should contain_file('/etc/sysconfig/modules/foo.modules').with({
             'ensure'  => 'absent',


### PR DESCRIPTION
Very basic support to be able to use kmod::load, loads and unloads
modules correctly, and updates the /etc/sysconfig/kernel file
accordingly. Other defined types etc. weren't touched since
not needed for now by me.

Add some specs for module_load for SLES, but they are not picked
up. With SLES added to metadata.json, travis showed messages like:
Can't find facts for 'sles-11.3-x86_64' for facter 1.7, skipping...