### PR TITLE
add option for archlinux

### DIFF
--- a/manifests/load.pp
+++ b/manifests/load.pp
@@ -80,6 +80,13 @@ define kmod::load(
         changes => $changes,
       }
     }
+    'Archlinux': {
+      file { "/etc/modules-load.d/${name}.conf":
+        ensure  => $ensure,
+        mode    => '0644',
+        content => "${name}\n",
+      }
+    }
     default: {
       fail "${module_name}: Unknown OS family ${::osfamily}"
     }


### PR DESCRIPTION
This adds the ability to load modules on Archlinux. This is tested in our env and working fine.