### PR TITLE
Add support for ensuring an alias is absent

### DIFF
--- a/manifests/alias.pp
+++ b/manifests/alias.pp
@@ -16,6 +16,7 @@ define kmod::alias(
   include ::kmod
 
   kmod::setting { "kmod::alias ${title}":
+    ensure   => $ensure,
     module   => $aliasname,
     file     => $file,
     category => 'alias',

--- a/spec/defines/kmod_alias_spec.rb
+++ b/spec/defines/kmod_alias_spec.rb
@@ -37,6 +37,14 @@ describe 'kmod::alias', :type => :define do
         }) }
       end
 
+      context 'when ensure absent is specified' do
+        let(:params) do default_params.merge!({ :ensure => 'absent' }) end
+        it { should contain_kmod__alias('foo') }
+        it { should contain_kmod__setting('kmod::alias foo') .with({
+          'ensure'    => 'absent',
+        }) }
+      end
+
     end
   end
 end


### PR DESCRIPTION
Fixes #41 by passing ensure on to the kmod::settings type. Added test for ensure => absent.