### PR TITLE
Change setting to only remove option on absent

### DIFF
--- a/manifests/setting.pp
+++ b/manifests/setting.pp
@@ -30,7 +30,7 @@ define kmod::setting(
     }
 
     'absent': {
-      $changes = "rm ${category}[. = '${module}']"
+      $changes = "rm ${category}[. = '${module}']/${option} ${value}"
     }
 
     default: { fail ( "unknown ensure value ${ensure}" ) }


### PR DESCRIPTION
Hello,
I noticed that setting 'ensure => absent' on kmod::option/setting would remove the whole line, instead of just the particular option that was being managed. This change just modifies the augeas command when the option is 'absent' to only remove that particular setting if it is present.

I noticed this on a file where I had two options being managed, but one was occasionally set to be 'absent'. In these cases puppet would remove the whole line, then re-add the second option on every puppet run.

In my testing this change appears to work as I would expect, but I am not an augeas expert.