### PR TITLE
kmod::load: load modules the systemd way if the system runs systemd

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.13.1 < 5.0.0"
+      "version_requirement": ">=4.13.1 < 6.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -19,7 +19,9 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8",
+        "9"
       ]
     },
     {


### PR DESCRIPTION
These changes make kmod::load enable persistent module loading the systemd way, when the system is running systemd, as detected by the [service_provider fact](https://github.com/puppetlabs/puppetlabs-stdlib/blob/master/lib/facter/service_provider.rb).

I'm new to writing tests, so I don't know how [kmod_load_spec.rb](https://github.com/camptocamp/puppet-kmod/blob/master/spec/defines/kmod_load_spec.rb) should be updated to test for this new logic.