### PR TITLE
remove augeasversion check

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,9 +12,6 @@ class kmod (
   Optional[Hash] $list_of_loads      = {},
   Optional[Hash] $list_of_options    = {},
 ){
-  if versioncmp($::augeasversion, '0.9.0') < 0 {
-    fail('Augeas 0.10.0 or higher required')
-  }
   file { '/etc/modprobe.d': ensure => directory }
 
   file { [

--- a/spec/classes/kmod_spec.rb
+++ b/spec/classes/kmod_spec.rb
@@ -3,14 +3,6 @@ require 'spec_helper'
 describe 'kmod', :type => :class do
 
   on_supported_os.each do |os, facts|
-    context "on #{os} with augeas 0.8.9" do
-      let(:facts) do facts.merge({:augeasversion => '0.8.9'}) end
-      it do
-        expect {
-          should compile
-        }.to raise_error(/Augeas 0.10.0 or higher required/)
-      end
-    end
     context "on #{os}" do
       let(:facts) do
         facts.merge(  { :augeasversion => '1.2.0' } )


### PR DESCRIPTION
That fact has been restructured as part of the 3.0 Facter release,
which has been released more than four years.

In my specific use case (Debian Buster and Puppet 5.5), the fact is
not defined at all, which crashes this otherwise working module. The
proper fact to use would be `augeas.version` but I don't think it's
necessary to use that.

Augeas itself has been way beyond version 0.9 for years as well: 0.10
was released a good 8 years ago and 1.0, 7 years ago (2012).

Debian unstable, testing, stable, oldstable and oldold stable all run
sufficiently new versions of Augeas (1.12, 1.12, 1.11, 1.8 and 1.2,
respectively) that this check is now superfluous. I strongly doubt
anyone is still running 0.8 anywhere. And even if then, their manifest
would break, but they would *already* break *because* of that
check.

So leave those old version behind, we want to work with Puppet and
Facter 3 instead.